### PR TITLE
#8 - 가짜 데이터 자료형 enum 설계

### DIFF
--- a/src/main/java/org/example/testdata/domain/SchemaField.java
+++ b/src/main/java/org/example/testdata/domain/SchemaField.java
@@ -2,12 +2,13 @@ package org.example.testdata.domain;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.*;
+import org.example.testdata.domain.constant.MockDataType;
 
 @Getter@Setter@ToString
 public class SchemaField {
 
     private String fieldName;
-    private String mockDataType;
+    private MockDataType mockDataType;
     private Integer fieldOrder;
     private Integer blankPercent;
 

--- a/src/main/java/org/example/testdata/domain/constant/MockDataType.java
+++ b/src/main/java/org/example/testdata/domain/constant/MockDataType.java
@@ -1,0 +1,59 @@
+package org.example.testdata.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum MockDataType {
+
+    STRING(Set.of("minLength", "maxLength"), null),
+    NUMBER(Set.of("min", "max", "decimals"), null),
+    BOOLEAN(Set.of(), null),
+    DATETIME(Set.of("from", "to"), null),
+    ENUM(Set.of("elements"), null),
+
+    SENTENCE(Set.of("minSentences", "maxSentences"), STRING),
+    PARAGRAPH(Set.of("minParagraphs", "maxParagraphs"), STRING),
+    UUID(Set.of(), STRING),
+    EMAIL(Set.of(), STRING),
+    CAR(Set.of(), STRING),
+    ROW_NUMBER(Set.of("start, step"), NUMBER),
+    NAME(Set.of(), STRING),
+    ;
+
+    private final Set<String> requiredOptions;
+    private final MockDataType baseType;
+
+    private static final List<MockDataTypeObject> objects = Stream.of(values())
+            .map(MockDataType::toObject)
+            .toList();
+
+
+    public static List<MockDataTypeObject> toObjects() {
+        return objects;
+    }
+
+    public boolean isBaseType() { return baseType == null; }
+
+    public MockDataTypeObject toObject() {
+        return new MockDataTypeObject(
+                this.name(),
+                this.requiredOptions,
+                this.baseType == null ? null : this.baseType.name()
+        );
+    }
+
+
+    public record MockDataTypeObject(
+            String name,
+            Set<String> requiredOptions,
+            String baseType
+    ) {}
+
+}
+

--- a/src/test/java/org/example/testdata/domain/constant/MockDataTypeTest.java
+++ b/src/test/java/org/example/testdata/domain/constant/MockDataTypeTest.java
@@ -1,0 +1,52 @@
+package org.example.testdata.domain.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@DisplayName("[Domain] 테스트 데이터 자료형 테스트")
+class MockDataTypeTest {
+
+
+
+    @DisplayName("자료형이 주어지면, 해당 원소의 이름을 리턴한다")
+    @Test
+    void givenMockDataType_WhenReading_thenReturnsEnumElementName(){
+        //given
+        MockDataType mockDataType= MockDataType.STRING;
+
+        //when
+        String elementName= mockDataType.toString();
+
+        //then
+
+        assertThat(elementName).isEqualTo(MockDataType.STRING.name());
+
+
+
+    }
+
+
+    @DisplayName("자료형이 주어지면, 해당 원소의 데이터를 리턴한다.")
+    @Test
+    void givenMockDataType_WhenReading_thenReturnsEnumElementObject(){
+        //given
+        MockDataType mockDataType= MockDataType.STRING;
+
+        //when
+        MockDataType.MockDataTypeObject result= MockDataType.STRING.toObject();
+
+        //then
+
+//        assertThat(result.toString()).isEqualTo("""
+//                {
+//                "name": STRING", "requiredOptions": ["minLength","maxLength","pattern"],"baseType": null
+//                }
+//                """);
+        assertThat(result.toString()).contains("name","requiredOptions","baseType");
+
+    }
+
+}


### PR DESCRIPTION
가짜 데이터 타입은 DB에는 저장 관리하지 않기로 함.
따라서 타입을 용이하게 관리할 수 있는 enum을 선택
enum 정보는 가짜 데이터 생성에 필요한 옵션 정보를 들고 있고,
이를 프론트에도 넘겨줄 수 있도록하는 방법을 추가로 고민함.
구현한 내용을 간단히 문자열 변환하여 테스트함