### PR TITLE
#39- 테스트용 인메모리 db:h2 프로퍼티 셋업

### DIFF
--- a/src/main/java/org/example/testdata/domain/constant/MockDataType.java
+++ b/src/main/java/org/example/testdata/domain/constant/MockDataType.java
@@ -1,9 +1,5 @@
 package org.example.testdata.domain.constant;
 
-<<<<<<< HEAD
-
-=======
->>>>>>> 7cba6d1329fbf9e0ae24dfd4deab01a2b315cf43
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -59,9 +55,6 @@ public enum MockDataType {
             String baseType
     ) {}
 
-<<<<<<< HEAD
-}
-=======
 }
 
->>>>>>> 7cba6d1329fbf9e0ae24dfd4deab01a2b315cf43
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,15 @@
+debug: false
 
 
 spring:
   application.name: test-data
+  datasource:
+    url: jdbc:h2:mem:testdb
+    #싱글 데이터 소스를 사용하기 때문에 아래 줄 명시는 안해도 됨
+    # driver-class-name: org.h2.Driver
+  # 경고문 설정
+  # JPA 설정
 
-# 경고문 설정
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -16,5 +22,13 @@ spring:
   sql:
     init:
       mode: always
-# JPA 설정
-debug: false
+
+#새로운 문서
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    #호환성을 MYSQL에 맞게 설정
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE

--- a/src/test/java/org/example/testdata/domain/constant/MockDataTypeTest.java
+++ b/src/test/java/org/example/testdata/domain/constant/MockDataTypeTest.java
@@ -4,10 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-<<<<<<< HEAD
-import static org.junit.jupiter.api.Assertions.*;
-=======
->>>>>>> 7cba6d1329fbf9e0ae24dfd4deab01a2b315cf43
 
 
 @DisplayName("[Domain] 테스트 데이터 자료형 테스트")


### PR DESCRIPTION
스프링 부트에서 h2를 이용할 수 있도록 H2 프로퍼티 설정을 추가  아직 사용하는 스프링 프로파일은 아니지만 미리 mysql 호환성 모드를 준비하기 위해 'test' 프로파일과 관련설정도 추가